### PR TITLE
Add missing permission checks to command

### DIFF
--- a/src/main/java/io/github/sakuraryoko/afkplus/commands/AfkPlusCommand.java
+++ b/src/main/java/io/github/sakuraryoko/afkplus/commands/AfkPlusCommand.java
@@ -23,6 +23,7 @@ public class AfkPlusCommand {
         public static void register() {
                 CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> dispatcher.register(
                         literal("afkplus")
+                                .requires(Permissions.require("afkplus.afkplus", CONFIG.afkPlusOptions.afkPlusCommandPermissions))
                                 .executes(ctx -> afkAbout(ctx.getSource(), ctx))
                                 .then(literal("ex")
                                         .requires(Permissions.require("afkplus.afkplus.ex", 4))
@@ -56,6 +57,7 @@ public class AfkPlusCommand {
                                         )
                                 )
                                 .then(literal("damage")
+                                        .requires(Permissions.require("afkplus.afkplus.damage", CONFIG.afkPlusOptions.afkPlusCommandPermissions))
                                         .then(literal("disable")
                                                 .requires(Permissions.require("afkplus.afkplus.damage.disable", CONFIG.afkPlusOptions.afkPlusCommandPermissions))
                                                 .then(argument("player", EntityArgumentType.player())


### PR DESCRIPTION
Found that both `/afkplus` and `/afkplus damage` didn't have permission checks on them.
This is not a security problem since damage has permission checks on both the enable and disable subcommand and afkplus just outputs information.
However, it meant that players who have no permission to execute the damage command could see it as an option which was confusing. Tested this code on a server and it's fixed the problem that players could see the damage subcommand.